### PR TITLE
Fix typos on README & remove unused imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ CONSUMER_SECRET='YOUR_CARTODB_CONSUMER_SECRET'
 cartodb_domain = 'YOUR_CARTODB_DOMAIN'
 cl = CartoDBOAuth(CONSUMER_KEY, CONSUMER_SECRET, user, password, cartodb_domain)
 try:
-print cl.sql('select * from mytable')
+    print cl.sql('select * from mytable')
 except CartoDBException as e:
-print ("some error ocurred", e)
+    print ("some error ocurred", e)
 ```
 
 Using API KEY
@@ -61,7 +61,6 @@ You can get you api key in https://YOUR_USER.cartodb.com/your_apps/api_key
 ```python
 from cartodb import CartoDBAPIKey, CartoDBException
 
-user =  'me@mail.com'
 API_KEY ='YOUR_CARTODB_API_KEY'
 cartodb_domain = 'YOUR_CARTODB_DOMAIN'
 cl = CartoDBAPIKey(API_KEY, cartodb_domain)

--- a/cartodb/cartodb.py
+++ b/cartodb/cartodb.py
@@ -28,24 +28,19 @@ import urlparse
 import oauth2 as oauth
 import urllib
 import httplib2
-import urllib2
-import sys
 
 try:
     import json
 except ImportError:
     import simplejson as json
 
-from oauth2 import Request
-
-#REQUEST_TOKEN_URL = 'https://%(user)s.%(domain)s/oauth/request_token'
 ACCESS_TOKEN_URL = '%(protocol)s://%(user)s.%(domain)s/oauth/access_token'
-#AUTHORIZATION_URL = 'https://%(user)s.%(domain)s/oauth/authorize'
 RESOURCE_URL = '%(protocol)s://%(user)s.%(domain)s/api/%(api_version)s/sql'
 
 
 class CartoDBException(Exception):
     pass
+
 
 class CartoDBBase(object):
     """ basic client to access cartodb api """
@@ -71,6 +66,7 @@ class CartoDBBase(object):
                 parse_json = False
         p = urllib.urlencode(params)
         url = self.resource_url
+
         # depending on query size do a POST or GET
         if len(sql) < self.MAX_GET_QUERY_LEN and not do_post:
             url = url + '?' + p
@@ -94,9 +90,10 @@ class CartoDBBase(object):
 
         return None
 
+
 class CartoDBOAuth(CartoDBBase):
     """
-    This client allows to auth in cartodb using oauth. 
+    This client allows to auth in cartodb using oauth.
     """
     def __init__(self, key, secret, email, password, cartodb_domain, host='cartodb.com', protocol='https', proxy_info=None, *args, **kwargs):
         super(CartoDBOAuth, self).__init__(cartodb_domain, host, protocol, *args, **kwargs)
@@ -133,6 +130,7 @@ class CartoDBOAuth(CartoDBBase):
         )
         return resp, content
 
+
 class CartoDBAPIKey(CartoDBBase):
     """
     this class provides you access to auth CartoDB API using your API. You can find your API key in https://USERNAME.cartodb.com/your_apps/api_key.
@@ -144,7 +142,7 @@ class CartoDBAPIKey(CartoDBBase):
         self.api_key = api_key
         self.client = httplib2.Http()
         if protocol != 'https':
-            warnings.warn("you are using API key auth method with http") 
+            warnings.warn("you are using API key auth method with http")
 
 
     def req(self, url, http_method="GET", http_headers={}, body=''):
@@ -159,4 +157,3 @@ class CartoDBAPIKey(CartoDBBase):
             resp, content = self.client.request(url, headers=http_headers)
 
         return resp, content
-


### PR DESCRIPTION
- The `README` file was showing bad indented code + it was using a variable user that was not really needed.
- The `cartodb.py` was importing several unused modules.