### PR TITLE
Use requests module to make API calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,64 @@
+### Python template
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
 
 *.swp
-*.pyc
 secret.py
 env
-
-

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,3 +1,3 @@
-
 Javier Santana <jsantana@vizzuality.com>
 mapbutcher (https://github.com/mapbutcher)
+Daniel Carrion <daniel@cartodb.com>

--- a/cartodb/cartodb.py
+++ b/cartodb/cartodb.py
@@ -88,9 +88,6 @@ class CartoDBBase(object):
             raise CartoDBException('Unknown error occurred')
 
 
-        return None
-
-
 class CartoDBOAuth(CartoDBBase):
     """
     This client allows to auth in cartodb using oauth.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-
-oauth2
-simplejson
+requests==2.7.0
+simplejson==3.7.3
+requests_oauthlib==0.5.0
+oauth2==1.5.211


### PR DESCRIPTION
[requests](http://docs.python-requests.org/en/latest/) provides a much better way of making API calls, and I really need that for further improvements (like import API support, which is coming next, or named maps support, which will come later)
everything is backward-compatible, and no changes have been made on the use of the classes/methods (yet)

other improvements:
* fixed proxy support
* better and updated documentation
* more complete .gitignore

drawbacks:
* dropped 2.5 support, as current requests is only compatible with 2.6+